### PR TITLE
Added folder icons and unified search result indentation

### DIFF
--- a/Editor/SearchWindow.cs
+++ b/Editor/SearchWindow.cs
@@ -2,11 +2,13 @@
 using System.Linq;
 using UnityEngine;
 using UnityEditor.Experimental.GraphView;
+using UnityEditor.Experimental;
 
 namespace BlueGraph.Editor
 {
     public class SearchWindow : ScriptableObject, ISearchWindowProvider
     {
+
         public CanvasView Target { get; set; }
 
         public PortView SourcePort { get; set; }
@@ -107,6 +109,8 @@ namespace BlueGraph.Editor
     
     internal class SearchGroup
     {
+        private static Texture folderIcon = EditorResources.Load<Texture>("d_Folder Icon");
+
         public SearchGroup(int depth)
         {
             Depth = depth;
@@ -125,7 +129,8 @@ namespace BlueGraph.Editor
             // Add subgroups
             foreach (var group in Subgroups)
             {
-                entry = new SearchTreeGroupEntry(new GUIContent(group.Key))
+                GUIContent content = new GUIContent(" " + group.Key, folderIcon);
+                entry = new SearchTreeGroupEntry(content)
                 {
                     level = Depth
                 };
@@ -137,7 +142,8 @@ namespace BlueGraph.Editor
             // Add nodes
             foreach (var result in Results)
             {
-                entry = new SearchTreeEntry(new GUIContent(result.Name))
+                GUIContent content = new GUIContent("      " + result.Name);
+                entry = new SearchTreeEntry(content)
                 {
                     level = Depth,
                     userData = result


### PR DESCRIPTION
The fact that node results were indented differently than folders bothered me, so I changed them to be equal.
However, since this change made it more difficult to see which results are folders and which are nodes at a glance, I also added a folder icon next to all folder results.

![image](https://user-images.githubusercontent.com/17457177/97094300-19274500-1654-11eb-97b9-92fa697db096.png)